### PR TITLE
Remove emoji fleet-wide: enforce no-emoji directive

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -27,7 +27,7 @@ if [[ -z "$NEW_VERSION" ]]; then
 fi
 
 # Basic semver validation (major.minor.patch)
-if! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Error: version must be in semver format (e.g. 1.5.0), got: $NEW_VERSION" >&2
     exit 1
 fi

--- a/scripts/setup-docker-integration.sh
+++ b/scripts/setup-docker-integration.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 echo "==> Setting up Stratavore Docker integration"
 
 # Check if lex-docker is running
-if! docker ps | grep -q "lex-postgres"; then
+if ! docker ps | grep -q "lex-postgres"; then
     echo "ERROR: lex-docker infrastructure not running"
     echo "Start it with: cd ~/meridian-home/projects/lex-docker &&./scripts/deploy-stack.sh"
     exit 1
@@ -66,7 +66,7 @@ mkdir -p ~/.config/stratavore
 mkdir -p ~/.local/share/stratavore
 
 # Create default config if it doesn't exist
-if [! -f ~/.config/stratavore/stratavore.yaml ]; then
+if [ ! -f ~/.config/stratavore/stratavore.yaml ]; then
     cat > ~/.config/stratavore/stratavore.yaml <<'EOF'
 database:
   postgresql:


### PR DESCRIPTION
## Summary

- Removes all emoji characters from markdown and script files across the repository
- Replaces status emoji with plain-text equivalents ([OK], [FAIL], [INFO], etc.)
- Enforces the no-emoji directive fleet-wide

## Fix note

A follow-up commit repairs bash syntax errors introduced by the emoji removal script, which stripped spaces adjacent to operators in two files:
- bump-version.sh: if! -> if !
- setup-docker-integration.sh: if! -> if !, [! -> [ !

Both files pass bash -n after the fix.

## Test plan

- [ ] Review emoji removal changes in markdown files
- [ ] Verify bash scripts pass syntax check (bash -n)
- [ ] Confirm no regressions in script functionality