### PR TITLE
Add HTTP endpoints for project/session/metrics

### DIFF
--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -121,6 +121,14 @@ func (c *PostgresClient) GetProject(ctx context.Context, name string) (*types.Pr
 	return &project, nil
 }
 
+// ArchiveProject soft-deletes a project by setting its status to archived
+func (c *PostgresClient) ArchiveProject(ctx context.Context, name string) error {
+	_, err := c.pool.Exec(ctx, `
+		UPDATE projects SET status = $1, updated_at = NOW() WHERE name = $2
+	`, types.ProjectArchived, name)
+	return err
+}
+
 // ListProjects returns all projects
 func (c *PostgresClient) ListProjects(ctx context.Context, status string) ([]*types.Project, error) {
 	query := `

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"time"
+
+	"github.com/meridian-lex/stratavore/pkg/types"
 )
 
 // Manually defined protobuf-compatible types
@@ -67,6 +69,18 @@ type GetStatusRequest struct{}
 
 type TriggerReconciliationRequest struct{}
 
+type DeleteProjectRequest struct {
+	Name string
+}
+
+type ListSessionsRequest struct {
+	ProjectName string
+}
+
+type GetSessionRequest struct {
+	SessionID string
+}
+
 // ===== RESPONSE TYPES =====
 
 type LaunchRunnerResponse struct {
@@ -121,6 +135,21 @@ type TriggerReconciliationResponse struct {
 	ReconciledCount  int32
 	FailedRunnerIDs  []string
 	Error            string
+}
+
+type DeleteProjectResponse struct {
+	Success bool
+	Error   string
+}
+
+type ListSessionsResponse struct {
+	Sessions []*types.Session
+	Error    string
+}
+
+type GetSessionResponse struct {
+	Session *types.Session
+	Error   string
 }
 
 // ===== MODEL TYPES =====


### PR DESCRIPTION
## Summary

- Adds GET /api/v1/projects/get — retrieve a project by name (400 if name missing)
- Adds POST /api/v1/projects/delete — soft-delete (archive) a project via a new ArchiveProject storage method
- Adds GET /api/v1/sessions/list — list resumable sessions for a given project (400 if project missing)
- Adds GET /api/v1/sessions/get — retrieve a single session by ID (400 if session_id missing)
- Adds GET /api/v1/metrics — return global daemon metrics, reusing GetStatus internally

## Changes

- pkg/api/types.go: added DeleteProjectRequest/Response, ListSessionsRequest/Response, GetSessionRequest/Response; imported pkg/types for Session references
- internal/storage/postgres.go: added ArchiveProject method (UPDATE projects SET status='archived', updated_at=NOW())
- internal/daemon/http_server.go: added 5 handler methods and registered all 5 routes in NewHTTPServer

## Test plan

- [ ] Build passes: go build ./...
- [ ] GET /api/v1/projects/get?name=test returns project JSON or 400 if name omitted
- [ ] POST /api/v1/projects/delete with {"name":"test"} returns {"Success":true} and sets status to archived
- [ ] GET /api/v1/sessions/list?project=test returns session array (empty ok) or 400 if project omitted
- [ ] GET /api/v1/sessions/get?session_id=<id> returns session JSON or 400 if session_id omitted
- [ ] GET /api/v1/metrics returns GlobalMetrics JSON