### PR TITLE
feat: tmux session layer for persistent SSH connections

### DIFF
--- a/cmd/stratavore/main.go
+++ b/cmd/stratavore/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"time"
 
@@ -49,7 +50,7 @@ var (
 func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file path")
-	rootCmd.PersistentFlags().StringVar(&flagsVar, "flags", "", "Claude Code flags")
+	rootCmd.PersistentFlags().StringVar(&flagsVar, "flags", "", "Meridian Lex flags")
 	rootCmd.PersistentFlags().BoolVar(&godMode, "god", false, "God mode (full access)")
 	rootCmd.PersistentFlags().StringVar(&preset, "preset", "", "Use preset configuration")
 	rootCmd.PersistentFlags().BoolVar(&grpc, "grpc", false, "Use gRPC client (default false)")
@@ -58,7 +59,7 @@ func init() {
 	newCmd.Flags().StringP("path", "p", "", "Project path (default: current directory)")
 	newCmd.Flags().StringP("description", "d", "", "Project description")
 
-	launchCmd.Flags().StringSliceP("flag", "f", nil, "Claude Code flags")
+	launchCmd.Flags().StringSliceP("flag", "f", nil, "Meridian Lex flags")
 	launchCmd.Flags().StringSliceP("capability", "c", nil, "Capabilities to enable")
 
 	killCmd.Flags().BoolP("force", "f", false, "Force kill (SIGKILL)")
@@ -86,7 +87,7 @@ func main() {
 var rootCmd = &cobra.Command{
 	Use:   "stratavore [project]",
 	Short: "AI Development Workspace Orchestrator",
-	Long: `Stratavore manages multiple Claude Code sessions across projects,
+	Long: `Stratavore manages multiple Meridian Lex sessions across projects,
 providing global state visibility, session resumption, and resource management.`,
 	Version: fmt.Sprintf("%s (built %s, commit %s)", Version, BuildTime, Commit),
 	Run:     rootHandler,
@@ -365,12 +366,48 @@ var runnersCmd = &cobra.Command{
 
 var attachCmd = &cobra.Command{
 	Use:   "attach <runner-id>",
-	Short: "Attach to running instance",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Short: "Attach to a running tmux session",
+	Long: `Re-attach to the tmux session wrapping a running runner.
+
+The runner must have been launched while tmux was available on the daemon host.
+Use this after an SSH disconnect to resume the session.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		runnerID := args[0]
-		fmt.Printf("Attaching to runner: %s\n", runnerID)
-		fmt.Println("(Attach implementation TODO - requires PTY handling)")
+		ctx := context.Background()
+
+		apiClient := getAPIClient()
+
+		resp, err := apiClient.GetRunner(ctx, runnerID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve runner: %w", err)
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("runner not found: %s", resp.Error)
+		}
+		if resp.Runner == nil {
+			return fmt.Errorf("runner %s not found", runnerID)
+		}
+
+		sessionName := resp.Runner.SessionName
+		if sessionName == "" {
+			return fmt.Errorf("runner %s has no tmux session (launched without tmux or session not recorded)", runnerID)
+		}
+
+		// Verify the tmux session is still alive
+		checkCmd := exec.Command("tmux", "has-session", "-t", sessionName)
+		if err := checkCmd.Run(); err != nil {
+			return fmt.Errorf("tmux session %q not found — runner may have exited (runner status: %s)", sessionName, resp.Runner.Status)
+		}
+
+		fmt.Printf("Attaching to tmux session %q for runner %s...\n", sessionName, runnerID[:8])
+
+		// Replace current process with tmux attach — stdin/stdout/stderr pass through
+		attachExec := exec.Command("tmux", "attach-session", "-t", sessionName)
+		attachExec.Stdin = os.Stdin
+		attachExec.Stdout = os.Stdout
+		attachExec.Stderr = os.Stderr
+		return attachExec.Run()
 	},
 }
 

--- a/internal/daemon/grpc_server.go
+++ b/internal/daemon/grpc_server.go
@@ -295,6 +295,7 @@ func convertRunnerToAPI(r *types.Runner) *api.Runner {
 		Environment:        r.Environment,
 		SessionID:          r.SessionID,
 		ConversationMode:   string(r.ConversationMode),
+		SessionName:        r.SessionName,
 		TokensUsed:         r.TokensUsed,
 		CPUPercent:         r.CPUPercent,
 		MemoryMB:           r.MemoryMB,

--- a/internal/daemon/runner_manager.go
+++ b/internal/daemon/runner_manager.go
@@ -17,13 +17,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// RunnerManager manages Claude Code runner lifecycles
+// RunnerManager manages Meridian Lex runner lifecycles
 type RunnerManager struct {
-	db            *storage.PostgresClient
-	messaging     *messaging.Client
-	logger        *zap.Logger
-	activeRunners map[string]*ManagedRunner
-	mu            sync.RWMutex
+	db             *storage.PostgresClient
+	messaging      *messaging.Client
+	logger         *zap.Logger
+	activeRunners  map[string]*ManagedRunner
+	mu             sync.RWMutex
+	tmuxAvailable  bool
 }
 
 // ManagedRunner represents an actively managed runner
@@ -40,11 +41,19 @@ func NewRunnerManager(
 	messaging *messaging.Client,
 	logger *zap.Logger,
 ) *RunnerManager {
+	_, tmuxErr := exec.LookPath("tmux")
+	tmuxAvailable := tmuxErr == nil
+	if tmuxAvailable {
+		logger.Info("tmux detected: runners will be wrapped in named sessions")
+	} else {
+		logger.Warn("tmux not found: runners will launch directly (no session persistence)")
+	}
 	return &RunnerManager{
 		db:            db,
 		messaging:     messaging,
 		logger:        logger,
 		activeRunners: make(map[string]*ManagedRunner),
+		tmuxAvailable: tmuxAvailable,
 	}
 }
 
@@ -113,10 +122,27 @@ func (rm *RunnerManager) startAgent(
 		args = append(args, "--claude-flag", flag)
 	}
 
-	// Create command with context for graceful shutdown
-	cmd, err := launchAgent(ctx, args) // This will return the command, but we need to set it up first
-	if err != nil {
-		return nil, fmt.Errorf("launch agent: %w", err)
+	// Build command — wrap in tmux session when available so the process
+	// survives SSH disconnects and can be re-attached via stratavore attach.
+	var cmd *exec.Cmd
+	var sessionName string
+
+	if rm.tmuxAvailable {
+		sessionName = "stratavore-" + runner.ID[:8]
+		// Resolve agent binary path first
+		agentPath, err := resolveAgentPath()
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent path: %w", err)
+		}
+		// tmux new-session -d -s <name> -- <agentBin> <args...>
+		tmuxArgs := append([]string{"new-session", "-d", "-s", sessionName, "--", agentPath}, args...)
+		cmd = exec.CommandContext(ctx, "tmux", tmuxArgs...)
+	} else {
+		var err error
+		cmd, err = launchAgent(ctx, args)
+		if err != nil {
+			return nil, fmt.Errorf("launch agent: %w", err)
+		}
 	}
 
 	// Set up logging (could redirect to structured log files)
@@ -129,6 +155,17 @@ func (rm *RunnerManager) startAgent(
 	}
 
 	pid := cmd.Process.Pid
+
+	// If running under tmux, store the session name in the DB
+	if rm.tmuxAvailable && sessionName != "" {
+		runner.SessionName = sessionName
+		if err := rm.db.UpdateRunnerSessionName(ctx, runner.ID, sessionName); err != nil {
+			rm.logger.Warn("failed to store session name",
+				zap.String("runner_id", runner.ID),
+				zap.String("session_name", sessionName),
+				zap.Error(err))
+		}
+	}
 
 	// Update runner with runtime ID (PID)
 	if err := rm.db.UpdateRunnerRuntimeID(ctx, runner.ID, fmt.Sprintf("%d", pid)); err != nil {
@@ -151,14 +188,12 @@ func (rm *RunnerManager) startAgent(
 	return managed, nil
 }
 
-// launchAgent returns an exec.Cmd pointing to stratavore-agent
-func launchAgent(ctx context.Context, args []string) (*exec.Cmd, error) {
+// resolveAgentPath returns the path to the stratavore-agent binary
+func resolveAgentPath() (string, error) {
 	exeName := "stratavore-agent"
 	if runtime.GOOS == "windows" {
 		exeName += ".exe"
 	}
-
-	var agentPath string
 
 	// First try same directory as this executable
 	exePath, err := os.Executable()
@@ -166,15 +201,20 @@ func launchAgent(ctx context.Context, args []string) (*exec.Cmd, error) {
 		exeDir := filepath.Dir(exePath)
 		candidate := filepath.Join(exeDir, exeName)
 		if _, err := os.Stat(candidate); err == nil {
-			agentPath = candidate
+			return candidate, nil
 		}
 	}
 
-	// Fallback to PATH if not found
-	if agentPath == "" {
-		agentPath = exeName
-	}
+	// Fallback to PATH
+	return exeName, nil
+}
 
+// launchAgent returns an exec.Cmd pointing to stratavore-agent
+func launchAgent(ctx context.Context, args []string) (*exec.Cmd, error) {
+	agentPath, err := resolveAgentPath()
+	if err != nil {
+		return nil, err
+	}
 	cmd := exec.CommandContext(ctx, agentPath, args...)
 	return cmd, nil
 }
@@ -252,6 +292,15 @@ func (rm *RunnerManager) StopRunner(ctx context.Context, runnerID string) error 
 	}
 
 	rm.logger.Info("stopping runner", zap.String("runner_id", runnerID))
+
+	// Kill tmux session if present — this terminates the runner cleanly
+	if managed.Runner.SessionName != "" {
+		if err := exec.Command("tmux", "kill-session", "-t", managed.Runner.SessionName).Run(); err != nil {
+			rm.logger.Warn("failed to kill tmux session",
+				zap.String("session_name", managed.Runner.SessionName),
+				zap.Error(err))
+		}
+	}
 
 	// Signal stop
 	close(managed.StopCh)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -337,7 +337,7 @@ func (c *PostgresClient) GetRunner(ctx context.Context, runnerID string) (*types
 		       status, flags, capabilities, environment, session_id, conversation_mode,
 		       tokens_used, cpu_percent, memory_mb, restart_attempts, max_restart_attempts,
 		       started_at, last_heartbeat, heartbeat_ttl_seconds, terminated_at, exit_code,
-		       created_at, updated_at
+		       created_at, updated_at, session_name
 		FROM runners WHERE id = $1
 	`
 
@@ -345,6 +345,7 @@ func (c *PostgresClient) GetRunner(ctx context.Context, runnerID string) (*types
 	var flagsJSON, capsJSON, envJSON []byte
 	var nodeID, sessionID sql.NullString
 	var conversationMode sql.NullString
+	var sessionName sql.NullString
 	var cpuPercent sql.NullFloat64
 	var memoryMB, tokensUsed sql.NullInt64
 	var lastHeartbeat, terminatedAt sql.NullTime
@@ -358,6 +359,7 @@ func (c *PostgresClient) GetRunner(ctx context.Context, runnerID string) (*types
 		&runner.RestartAttempts, &runner.MaxRestartAttempts,
 		&runner.StartedAt, &lastHeartbeat, &runner.HeartbeatTTL,
 		&terminatedAt, &exitCode, &runner.CreatedAt, &runner.UpdatedAt,
+		&sessionName,
 	)
 
 	if err != nil {
@@ -398,6 +400,9 @@ func (c *PostgresClient) GetRunner(ctx context.Context, runnerID string) (*types
 	if exitCode.Valid {
 		ec := int(exitCode.Int32)
 		runner.ExitCode = &ec
+	}
+	if sessionName.Valid {
+		runner.SessionName = sessionName.String
 	}
 
 	return &runner, nil
@@ -835,6 +840,14 @@ func (c *PostgresClient) IncrementTokenUsage(ctx context.Context, scope, scopeID
 	return err
 }
 
+
+// UpdateRunnerSessionName stores the tmux session name for a runner
+func (c *PostgresClient) UpdateRunnerSessionName(ctx context.Context, runnerID, sessionName string) error {
+	_, err := c.pool.Exec(ctx, `
+		UPDATE runners SET session_name = $1 WHERE id = $2
+	`, sessionName, runnerID)
+	return err
+}
 // GetExpiredBudgets returns budgets that need rollover
 func (c *PostgresClient) GetExpiredBudgets(ctx context.Context, now time.Time) ([]*types.TokenBudget, error) {
 	query := `

--- a/migrations/postgres/0002_add_session_name.down.sql
+++ b/migrations/postgres/0002_add_session_name.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runners DROP COLUMN IF EXISTS session_name;

--- a/migrations/postgres/0002_add_session_name.up.sql
+++ b/migrations/postgres/0002_add_session_name.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runners ADD COLUMN IF NOT EXISTS session_name VARCHAR(128);

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -167,6 +167,7 @@ type Runner struct {
 	Environment        map[string]string
 	SessionID          string
 	ConversationMode   string
+	SessionName        string
 	TokensUsed         int64
 	CPUPercent         float64
 	MemoryMB           int64

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -40,7 +40,7 @@ const (
 	ModeResume   ConversationMode = "resume"
 )
 
-// Runner represents a Claude Code instance
+// Runner represents a Meridian Lex instance
 type Runner struct {
 	ID           string       `json:"id"`
 	RuntimeType  RuntimeType  `json:"runtime_type"`
@@ -55,6 +55,7 @@ type Runner struct {
 	
 	SessionID        string           `json:"session_id,omitempty"`
 	ConversationMode ConversationMode `json:"conversation_mode,omitempty"`
+	SessionName      string           `json:"session_name,omitempty"`
 	
 	TokensUsed       int64   `json:"tokens_used"`
 	CPUPercent       float64 `json:"cpu_percent"`


### PR DESCRIPTION
## Summary

- Runners are now wrapped in named tmux sessions when tmux is available on the daemon host
- Session name: `stratavore-<runner-id[:8]>` — deterministic, easy to identify
- `stratavore attach <runner-id>` re-enters the live session (survives SSH disconnect/reconnect)
- `stratavore kill <runner-id>` terminates the tmux session cleanly on teardown
- Falls back to direct process launch when tmux is unavailable (backwards compatible)
- DB migration `0002_add_session_name` adds `session_name VARCHAR(128)` column to runners table
- `session_name` propagates through: `types.Runner` -> `api.Runner` -> `convertRunnerToAPI` -> HTTP API

## Files changed

- `pkg/types/types.go` — `SessionName string` added to Runner struct
- `pkg/api/types.go` — `SessionName string` added to api.Runner struct
- `internal/daemon/grpc_server.go` — SessionName populated in convertRunnerToAPI
- `internal/daemon/runner_manager.go` — tmuxAvailable detection at init; startAgent wraps in tmux; StopRunner kills session; resolveAgentPath helper extracted
- `internal/storage/postgres.go` — GetRunner reads session_name; UpdateRunnerSessionName method added
- `cmd/stratavore/main.go` — attachCmd fully implemented (was a stub)
- `migrations/postgres/0002_add_session_name.{up,down}.sql` — schema migration

## Test plan

- [ ] Launch a runner and verify a tmux session named `stratavore-<id[:8]>` is created: `tmux ls`
- [ ] Disconnect SSH and reconnect — verify session persists with `tmux ls`
- [ ] `stratavore attach <id>` re-enters the session
- [ ] `stratavore kill <id>` removes the tmux session (verify with `tmux ls`)
- [ ] `stratavore runners` shows session_name in API response
- [ ] Launch daemon without tmux in PATH — verify graceful fallback to direct launch
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./... -short`