### PR TITLE
Centralize build artifacts to bin/ directory

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,7 +24,15 @@ jobs:
         run: go vet ./...
 
       - name: Build
-        run: go build ./...
+        run: make build
+
+      - name: Verify bin/ artifacts
+        run: |
+          ls -lh bin/
+          test -f bin/stratavore || (echo "bin/stratavore not found" && exit 1)
+          test -f bin/stratavored || (echo "bin/stratavored not found" && exit 1)
+          test -f bin/stratavore-agent || (echo "bin/stratavore-agent not found" && exit 1)
+          test -f bin/stratavore-migrate || (echo "bin/stratavore-migrate not found" && exit 1)
 
       - name: Test
         run: go test $(go list ./... | grep -v test/integration)

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -121,6 +121,25 @@ jobs:
           sed -i "s/Version   = \"[^\"]*\"/Version   = \"${{ steps.new_version.outputs.version }}\"/" cmd/stratavore-migrate/main.go
           echo "Updated cmd/stratavore-migrate/main.go"
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries for verification
+        run: make build
+
+      - name: Verify bin/ artifacts
+        run: |
+          echo "Verifying bin/ artifacts..."
+          ls -lh bin/
+          test -f bin/stratavore || (echo "bin/stratavore not found" && exit 1)
+          test -f bin/stratavored || (echo "bin/stratavored not found" && exit 1)
+          test -f bin/stratavore-agent || (echo "bin/stratavore-agent not found" && exit 1)
+          test -f bin/stratavore-migrate || (echo "bin/stratavore-migrate not found" && exit 1)
+          echo "All artifacts verified"
+
       - name: Verify version updates
         run: |
           echo "=== VERSION file ==="

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,13 @@
-/bin
+# Build output directory (all binaries)
+/bin/
+/dist/
+
 *.pyc
 # IDENTITY-EXCEPTION: functional internal reference — not for public exposure
 .claude/
 jobs/time_sessions.jsonl
 .env
 .env.local
-
-# Build artifacts (root level only)
-/stratavore
-/stratavored
-/stratavore-agent
-/stratavore-migrate
-
-# Build artifacts (in cmd/ subdirectories - specific binary names)
-cmd/stratavore/stratavore
-cmd/stratavored/stratavored
-cmd/stratavore-agent/stratavore-agent
-cmd/stratavore-migrate/stratavore-migrate
 
 # Compiled binaries
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 BINARY_NAME=stratavore
 DAEMON_NAME=stratavored
 AGENT_NAME=stratavore-agent
+MIGRATE_NAME=stratavore-migrate
 VERSION?=$(shell cat VERSION 2>/dev/null | tr -d '[:space:]' || echo "dev")
 BUILD_TIME=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
 COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
@@ -53,6 +54,8 @@ build:
 	@echo "[OK] bin/${DAEMON_NAME}"
 	go build ${LDFLAGS} -o bin/${AGENT_NAME} ./cmd/stratavore-agent
 	@echo "[OK] bin/${AGENT_NAME}"
+	go build ${LDFLAGS} -o bin/${MIGRATE_NAME} ./cmd/stratavore-migrate
+	@echo "[OK] bin/${MIGRATE_NAME}"
 	@echo ""
 	@echo "Build complete! Binaries in bin/"
 
@@ -61,6 +64,7 @@ quick:
 	@go build -o bin/${BINARY_NAME} ./cmd/stratavore
 	@go build -o bin/${DAEMON_NAME} ./cmd/stratavored
 	@go build -o bin/${AGENT_NAME} ./cmd/stratavore-agent
+	@go build -o bin/${MIGRATE_NAME} ./cmd/stratavore-migrate
 	@echo "Quick build complete"
 
 install: build
@@ -68,9 +72,11 @@ install: build
 	sudo cp bin/${BINARY_NAME} /usr/local/bin/
 	sudo cp bin/${DAEMON_NAME} /usr/local/bin/
 	sudo cp bin/${AGENT_NAME} /usr/local/bin/
+	sudo cp bin/${MIGRATE_NAME} /usr/local/bin/
 	sudo chmod +x /usr/local/bin/${BINARY_NAME}
 	sudo chmod +x /usr/local/bin/${DAEMON_NAME}
 	sudo chmod +x /usr/local/bin/${AGENT_NAME}
+	sudo chmod +x /usr/local/bin/${MIGRATE_NAME}
 	@echo "Creating config directory..."
 	mkdir -p ~/.config/stratavore
 	@echo "Installation complete!"
@@ -164,7 +170,7 @@ help:
 	@echo "  all                  - Generate protobuf and build all components (default)"
 	@echo "  deps                 - Download dependencies"
 	@echo "  proto                - Generate protobuf Go code (auto-detects tools)"
-	@echo "  build                - Build CLI, daemon, and agent"
+	@echo "  build                - Build CLI, daemon, agent, and migrate tools"
 	@echo "  quick                - Quick build without protobuf (development)"
 	@echo "  install              - Install binaries to /usr/local/bin"
 	@echo "  clean                - Remove build artifacts"


### PR DESCRIPTION
## Summary
Consolidates all build outputs to a single `bin/` directory, following standard Go project layout conventions.

## Changes

### Makefile
- All binaries now build to `bin/`

### .gitignore  
- Simplified from scattered patterns to single `/bin/` entry

### GitHub Actions
- `verify.yml`: Updated to use `make build` + artifact verification
- `version-bump.yml`: Added build step with bin/ validation

## Benefits
- Single .gitignore pattern for all binaries
- Standard Go project layout
- Easy cleanup
- No pattern conflicts

## Testing
All builds tested and passing (4/4 binaries).