### PR TITLE
fix: modify version bump workflow to create PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -45,8 +45,8 @@ jobs:
           COMMIT_MSG="$PR_TITLE"
           PR_BODY_TEXT="$PR_BODY"
 
-          if echo "$COMMIT_MSG" | grep -qiE "^BREAKING CHANGE:|breaking change:" || \
-             echo "$PR_BODY_TEXT" | grep -qiE "^BREAKING CHANGE:|breaking change:"; then
+          if echo "$COMMIT_MSG" | grep -qiE "^BREAKING CHANGE:|^breaking change:" || \
+             echo "$PR_BODY_TEXT" | grep -qiE "^BREAKING CHANGE:|^breaking change:"; then
             BUMP_TYPE="major"
           elif echo "$COMMIT_MSG" | grep -qiE "^feat(\(.+\))?:|^feature:"; then
             BUMP_TYPE="minor"


### PR DESCRIPTION
## Summary

The version bump workflow (`.github/workflows/version-bump.yml`) was attempting to push commits and tags directly to the protected main branch, resulting in rejection by GitHub's branch protection rules.

## Changes

1. **Added `pull-requests: write` permission** - Enables the workflow to create PRs
2. **Modified push strategy** - Creates a feature branch (`version-bump/{version}`) for version updates instead of pushing to main
3. **Automated PR creation** - Uses `gh pr create` to open a PR targeting main with full context linking back to the triggering PR
4. **Tag still created** - Release tags (`v{version}`) are still created and pushed separately

## How It Works Now

1. When a PR is merged that triggers version bump:
   - Workflow calculates new version
   - Updates VERSION file and all version fields in cmd/*/main.go
   - Creates and checks out feature branch `version-bump/{version}`
   - Commits changes and creates git tag
   - Pushes branch and tag to origin
   - Creates PR with automated summary

2. The PR will:
   - Trigger CI (Build & Test check)
   - Go through standard review process
   - Require approval before merge to main
   - Merge the version bump changes as a regular commit

## Testing

This change ensures compliance with the branch protection rules that require:
- PRs for all changes to main
- Status checks to pass before merge
- Clear audit trail of automated operations

## Links

Resolves issues with version bump blocking on protected main branches.

Co-Authored-By: Meridian Zero <noreply@meridian-lex.dev>

## Summary by Sourcery

Update the automated version bump workflow to run on merged pull requests and open a dedicated version-bump PR instead of pushing directly to main.

Enhancements:
- Change the workflow trigger from pushes to main to closed pull requests that were merged.
- Derive the semantic version bump type from the merged PR title instead of the commit message.
- Create a version-bump branch, commit version updates, tag the release, and push the branch and tag to origin.
- Automatically open a pull request from the version-bump branch to main with contextual information about the originating PR.
- Simplify and streamline build and verification steps in the workflow while preserving artifact checks.

CI:
- Grant the workflow contents and pull-requests write permissions to allow pushing branches/tags and creating PRs from the workflow.