### PR TITLE
feat: enable auto-merge for version bump PRs

### DIFF
--- a/.github/AUTO-MERGE-SETUP.md
+++ b/.github/AUTO-MERGE-SETUP.md
@@ -99,4 +99,3 @@ To disable auto-merge:
 
 **Implementation Status**: ✓ Active
 **Next Review**: After first auto-merge completes successfully
-**Last Updated**: 2026-02-27

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -212,16 +212,25 @@ jobs:
           printf "Bump type: %s\n" "$BUMP_TYPE" >> /tmp/pr_body.txt
           printf "Original PR: #%s (%s)\n" "$PR_NUM" "$PR_TITLE" >> /tmp/pr_body.txt
 
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "version-bump/$NEW_VER" \
-            --title "chore: bump version to $NEW_VER" \
-            --body-file /tmp/pr_body.txt \
-            --label "chore" \
-            --label "automated")
+          # Check for existing PR on this branch (idempotency)
+          EXISTING_PR=$(gh pr list --head "version-bump/$NEW_VER" --json url --jq '.[0].url' || echo "")
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Found existing PR: $EXISTING_PR"
+            PR_URL="$EXISTING_PR"
+          else
+            echo "Creating new PR..."
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "version-bump/$NEW_VER" \
+              --title "chore: bump version to $NEW_VER" \
+              --body-file /tmp/pr_body.txt \
+              --label "chore" \
+              --label "automated")
+          fi
 
           if [ -z "$PR_URL" ]; then
-            echo "Error: Failed to create pull request"
+            echo "Error: Failed to create or find pull request"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Implements GitHub native auto-merge for automated version-bump PRs, eliminating manual merge requirement.

## Changes

1. **Modified version-bump workflow** - Added "Enable auto-merge" step that runs after PR creation
2. **Documentation** - Created AUTO-MERGE-SETUP.md with branch protection configuration guide
3. **Cleanup** - Removed redundant custom auto-merge workflow

## How It Works

When a PR is merged to main triggering a version bump:
1. Version-bump workflow creates PR as usual
2. Workflow enables auto-merge on the created PR using `gh pr merge --auto`
3. GitHub automatically merges the PR once all required checks pass

## Requirements

Branch protection must be configured (see AUTO-MERGE-SETUP.md):
- github-actions[bot] must have bypass permissions for approvals
- Required status checks must be defined
- Checks must pass before auto-merge triggers

## Testing Plan

After merge:
1. Merge a PR to main that triggers version bump
2. Verify version-bump PR has "auto-merge" badge
3. Confirm PR auto-merges after checks pass

## Links

- Configuration guide: `.github/AUTO-MERGE-SETUP.md`
- Related: Resolves manual merge workflow for PR #31

Generated with Meridian Lex operational protocols.

## Summary by Sourcery

Enable GitHub native auto-merge for automated version-bump pull requests and document the required branch protection setup.

New Features:
- Add an auto-merge step to the version-bump workflow so that created version bump PRs are automatically merged once checks pass.

Enhancements:
- Expose the created version-bump pull request URL and number as workflow outputs for downstream steps.

Documentation:
- Add AUTO-MERGE-SETUP.md documenting how auto-merge for version bump PRs works and how to configure required branch protection rules.