### PR TITLE
fix: resolve version-bump workflow idempotency issues

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -169,7 +169,8 @@ jobs:
 
           # Delete remote branch if it exists (force-push will update it anyway)
           # Use git ls-remote to query remote directly (more reliable than stale tracking refs)
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+          # Use grep -qF for fixed-string match (branch name contains dots)
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -qF "$BRANCH_NAME"; then
             git push origin --delete "$BRANCH_NAME" || true
           fi
 
@@ -267,7 +268,7 @@ jobs:
             echo "::warning::LEXCODE_TOKEN not configured - skipping auto-approval"
             echo "PR created but requires manual approval before auto-merge can proceed."
           elif ! gh pr review "${{ steps.create_pr.outputs.PR_NUMBER }}" \
-            --repo ${{ github.repository }} \
+            --repo "${{ github.repository }}" \
             --approve \
             --body "Automated approval by LexCode for version bump to ${{ steps.new_version.outputs.version }}"; then
             echo "::warning::Failed to auto-approve PR #${{ steps.create_pr.outputs.PR_NUMBER }}"


### PR DESCRIPTION
## Problem

Version-bump workflow fails when an existing `version-bump/X.Y.Z` branch exists because git refuses to checkout when there are uncommitted changes to version files.

**Error:**
```
error: Your local changes to the following files would be overwritten by checkout:
	VERSION
	cmd/stratavore-agent/main.go
	...
Please commit your changes or stash them before you switch branches.
```

## Solution

Replace checkout-based idempotency with delete-and-recreate strategy:
1. Delete local branch if exists (`git branch -D`)
2. Delete remote branch if exists (`git push --delete`)
3. Create fresh branch (`git checkout -b`)
4. Use `--force-with-lease` on push to handle recreation

## Benefits

- Eliminates checkout conflicts with uncommitted changes
- Simpler logic than stash/pop approach
- Guaranteed clean state for each version bump
- Safe force-push with lease check

## Testing

After merge, next version bump should succeed without branch conflicts.

---
Generated with Meridian Lex operational protocols.

## Summary by Sourcery

Make the version-bump GitHub Actions workflow idempotent by recreating version-bump branches instead of reusing existing ones.

Bug Fixes:
- Prevent version-bump workflow failures when a version-bump/X.Y.Z branch already exists with conflicting local changes.

Enhancements:
- Simplify version-bump branch management by deleting existing local and remote branches before creating a fresh one and using force-with-lease when pushing.