### PR TITLE
fix: use LEXCODE_TOKEN for version-bump PR creation to enable workflow triggers

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -206,10 +206,11 @@ jobs:
           gh label create "automated" --description "Automated PR" --color "0e8a16" --force || true
 
       - name: Create pull request
-        # ISSUE #10: Permissions validation - uses GITHUB_TOKEN in GH_TOKEN env var
+        # Use LEXCODE_TOKEN instead of GITHUB_TOKEN to allow PR to trigger workflows
+        # PRs created with GITHUB_TOKEN don't trigger other workflows (GitHub security feature)
         id: create_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
         run: |
           # ISSUE #11: Explicit error handling for PR creation
           # Build PR body in file to avoid YAML syntax issues with embedded colons


### PR DESCRIPTION
## Problem

Version-bump PRs created by the workflow don't trigger the Build & Test workflow, blocking auto-merge.

**Root Cause:** The version-bump workflow uses `GITHUB_TOKEN` to create PRs. GitHub's security policy prevents PRs created with `GITHUB_TOKEN` from triggering other workflows (to prevent infinite loops).

**Impact:**
- Version-bump PRs (like #35, #37) don't trigger Build & Test workflow
- Branch protection requires Build & Test to pass
- Auto-merge cannot proceed
- Manual workflow trigger needed for every version bump

## Solution

Change PR creation step to use `LEXCODE_TOKEN` instead of `GITHUB_TOKEN`.

**Why this works:** Personal Access Tokens (PATs) don't have the same restriction - PRs created with PATs trigger workflows normally.

## Changes

```yaml
- name: Create pull request
  env:
-   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+   GH_TOKEN: ${{ secrets.LEXCODE_TOKEN }}
```

## Testing

After merge, the next version-bump PR should:
1. Trigger Build & Test workflow automatically
2. Pass all required checks
3. Auto-merge without manual intervention

## Related

- PR #37: Current version-bump PR requiring manual workflow trigger
- LEXCODE_TOKEN deployed fleet-wide on 2026-02-28

## Summary by Sourcery

Build:
- Switch the version-bump workflow to use LEXCODE_TOKEN instead of GITHUB_TOKEN for pull request creation to allow workflow triggers.